### PR TITLE
fix: double slash issue #6

### DIFF
--- a/src/api/buckets.rs
+++ b/src/api/buckets.rs
@@ -14,10 +14,12 @@ impl Client {
         request: Option<ListBucketsRequest>,
     ) -> Result<Buckets, RequestError> {
         let qs = serde_qs::to_string(&request).unwrap();
-        let url = match &qs[..] {
-            "" => format!("{}/api/v2/buckets", self.url),
-            _  => format!("{}/api/v2/buckets?{}", self.url, qs),
-        };
+        let mut endpoint = "/api/v2/buckets".to_owned();
+        if !qs.is_empty() {
+            endpoint.push_str("?");
+            endpoint.push_str(&qs);
+        }
+        let url = self.url(&endpoint);
 
         let response = self
             .request(Method::GET, &url)
@@ -46,7 +48,7 @@ impl Client {
         &self,
         post_bucket_request: Option<PostBucketRequest>,
     ) -> Result<(), RequestError> {
-        let create_bucket_url = format!("{}/api/v2/buckets", self.url);
+        let create_bucket_url = self.url("/api/v2/buckets");
 
         let response = self
             .request(Method::POST, &create_bucket_url)
@@ -68,11 +70,9 @@ impl Client {
     }
 
     /// Delete a bucket specified by bucket id.
-    pub async fn delete_bucket(
-        &self, 
-        bucket_id: &str
-    ) -> Result<(), RequestError> {
-        let url = format!("{}/api/v2/buckets/{}", self.url, bucket_id);
+    pub async fn delete_bucket(&self, bucket_id: &str) -> Result<(), RequestError> {
+        let url = self.url(&format!("/api/v2/buckets/{}", bucket_id));
+
         let response = self
             .request(Method::DELETE, &url)
             .send()

--- a/src/api/delete.rs
+++ b/src/api/delete.rs
@@ -31,7 +31,7 @@ impl Client {
         stop: NaiveDateTime,
         predicate: Option<String>,
     ) -> Result<(), RequestError> {
-        let delete_url = format!("{}/api/v2/delete", self.url);
+        let delete_url = self.url("/api/v2/delete");
         
         let body = serde_json::json!({
             "start": start.format("%Y-%m-%dT%H:%M:%SZ").to_string(),

--- a/src/api/health.rs
+++ b/src/api/health.rs
@@ -10,7 +10,7 @@ use snafu::ResultExt;
 impl Client {
     /// Get health of an instance
     pub async fn health(&self) -> Result<HealthCheck, RequestError> {
-        let health_url = format!("{}/health", self.url);
+        let health_url = self.url("/health");
         let response = self
             .request(Method::GET, &health_url)
             .send()

--- a/src/api/label.rs
+++ b/src/api/label.rs
@@ -18,7 +18,7 @@ impl Client {
     }
 
     async fn get_labels(&self, org_id: Option<&str>) -> Result<LabelsResponse, RequestError> {
-        let labels_url = format!("{}/api/v2/labels", self.url);
+        let labels_url = self.url("/api/v2/labels");
         let mut request = self.request(Method::GET, &labels_url);
 
         if let Some(id) = org_id {
@@ -40,7 +40,7 @@ impl Client {
 
     /// Retrieve a label by ID
     pub async fn find_label(&self, label_id: &str) -> Result<LabelResponse, RequestError> {
-        let labels_by_id_url = format!("{}/api/v2/labels/{}", self.url, label_id);
+        let labels_by_id_url = self.url(&format!("/api/v2/labels/{}", label_id));
         let response = self
             .request(Method::GET, &labels_by_id_url)
             .send()
@@ -65,7 +65,7 @@ impl Client {
         name: &str,
         properties: Option<HashMap<String, String>>,
     ) -> Result<LabelResponse, RequestError> {
-        let create_label_url = format!("{}/api/v2/labels", self.url);
+        let create_label_url = self.url("/api/v2/labels");
         let body = LabelCreateRequest {
             org_id: org_id.into(),
             name: name.into(),
@@ -96,7 +96,7 @@ impl Client {
         properties: Option<HashMap<String, String>>,
         label_id: &str,
     ) -> Result<LabelResponse, RequestError> {
-        let update_label_url = format!("{}/api/v2/labels/{}", &self.url, label_id);
+        let update_label_url = self.url(&format!("/api/v2/labels/{}", label_id));
         let body = LabelUpdate { name, properties };
         let response = self
             .request(Method::PATCH, &update_label_url)
@@ -118,7 +118,7 @@ impl Client {
 
     /// Delete a Label
     pub async fn delete_label(&self, label_id: &str) -> Result<(), RequestError> {
-        let delete_label_url = format!("{}/api/v2/labels/{}", &self.url, label_id);
+        let delete_label_url  = self.url(&format!("/api/v2/labels/{}", label_id));
         let response = self
             .request(Method::DELETE, &delete_label_url)
             .send()

--- a/src/api/organization.rs
+++ b/src/api/organization.rs
@@ -14,10 +14,12 @@ impl Client {
         request: ListOrganizationRequest,
     ) -> Result<Organizations, RequestError> {
         let qs = serde_qs::to_string(&request).unwrap();
-        let url = match &qs[..] {
-            "" => format!("{}/api/v2/orgs", self.url),
-            _  => format!("{}/api/v2/orgs?{}", self.url, qs),
-        };
+        let mut endpoint = "/api/v2/orgs".to_owned();
+        if !qs.is_empty() {
+            endpoint.push_str("?");
+            endpoint.push_str(&qs);
+        }
+        let url = self.url(&endpoint);
         
         let response = self
             .request(Method::GET, &url)

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -25,7 +25,7 @@ use crate::models::{
 impl Client {
     /// Get Query Suggestions
     pub async fn query_suggestions(&self) -> Result<FluxSuggestions, RequestError> {
-        let req_url = format!("{}/api/v2/query/suggestions", self.url);
+        let req_url = self.url("/api/v2/query/suggestions");
         let response = self
             .request(Method::GET, &req_url)
             .send()
@@ -46,11 +46,10 @@ impl Client {
 
     /// Query Suggestions with name
     pub async fn query_suggestions_name(&self, name: &str) -> Result<FluxSuggestion, RequestError> {
-        let req_url = format!(
-            "{}/api/v2/query/suggestions/{name}",
-            self.url,
-            name = crate::common::urlencode(name),
-        );
+        let req_url = self.url(&format!(
+            "/api/v2/query/suggestions/{name}",
+            name = crate::common::urlencode(name)
+        ));
 
         let response = self
             .request(Method::GET, &req_url)
@@ -71,11 +70,8 @@ impl Client {
     }
 
     /// Query
-    pub async fn query<T: FromMap>(
-        &self, 
-        query: Option<Query>
-    ) -> Result<Vec<T>, RequestError> {
-        let req_url = format!("{}/api/v2/query", self.url);
+    pub async fn query<T: FromMap>(&self, query: Option<Query>) -> Result<Vec<T>, RequestError> {
+        let req_url = self.url("/api/v2/query");
         let body = serde_json::to_string(&query.unwrap_or_default()).context(Serializing)?;
 
         let response = self
@@ -111,7 +107,7 @@ impl Client {
         &self,
         query: Option<Query>,
     ) -> Result<AnalyzeQueryResponse, RequestError> {
-        let req_url = format!("{}/api/v2/query/analyze", self.url);
+        let req_url = self.url("/api/v2/query/analyze");
 
         let response = self
             .request(Method::POST, &req_url)
@@ -138,7 +134,7 @@ impl Client {
         &self,
         language_request: Option<LanguageRequest>,
     ) -> Result<AstResponse, RequestError> {
-        let req_url = format!("{}/api/v2/query/ast", self.url);
+        let req_url = self.url("/api/v2/query/ast");
 
         let response = self
             .request(Method::POST, &req_url)

--- a/src/api/ready.rs
+++ b/src/api/ready.rs
@@ -10,7 +10,7 @@ use crate::{Client, Http, RequestError, ReqwestProcessing};
 impl Client {
     /// Get the readiness of an instance at startup
     pub async fn ready(&self) -> Result<bool, RequestError> {
-        let ready_url = format!("{}/ready", self.url);
+        let ready_url = self.url("/ready");
         let response = self
             .request(Method::GET, &ready_url)
             .send()

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -11,7 +11,7 @@ use crate::models::{IsOnboarding, OnboardingRequest, OnboardingResponse};
 impl Client {
     /// Check if database has default user, org, bucket
     pub async fn is_onboarding_allowed(&self) -> Result<bool, RequestError> {
-        let setup_url = format!("{}/api/v2/setup", self.url);
+        let setup_url = self.url("/api/v2/setup");
         let response = self
             .request(Method::GET, &setup_url)
             .send()
@@ -41,7 +41,7 @@ impl Client {
         retention_period_hrs: Option<i32>,
         retention_period_seconds: Option<i32>,
     ) -> Result<OnboardingResponse, RequestError> {
-        let setup_init_url = format!("{}/api/v2/setup", self.url);
+        let setup_init_url = self.url("/api/v2/setup");
 
         let body = OnboardingRequest {
             username: username.into(),
@@ -81,7 +81,7 @@ impl Client {
         retention_period_hrs: Option<i32>,
         retention_period_seconds: Option<i32>,
     ) -> Result<OnboardingResponse, RequestError> {
-        let setup_new_url = format!("{}/api/v2/setup/user", self.url);
+        let setup_new_url = self.url("/api/v2/setup/user");
 
         let body = OnboardingRequest {
             username: username.into(),

--- a/src/api/task.rs
+++ b/src/api/task.rs
@@ -14,10 +14,12 @@ impl Client {
         request: ListTasksRequest,
     ) -> Result<Tasks, RequestError> {
         let qs = serde_qs::to_string(&request).unwrap();
-        let url = match &qs[..] {
-            "" => format!("{}/api/v2/tasks", self.url),
-            _  => format!("{}/api/v2/tasks?{}", self.url, qs),
-        };
+        let mut endpoint = "/api/v2/tasks".to_owned();
+        if !qs.is_empty() {
+            endpoint.push_str("?");
+            endpoint.push_str(&qs);
+        }
+        let url = self.url(&endpoint);
 
         let response = self
             .request(Method::GET, &url)
@@ -44,7 +46,7 @@ impl Client {
         &self,
         request: CreateTaskRequest,
     ) -> Result<(), RequestError> {
-        let url = format!("{}/api/v2/tasks", self.url);
+        let url = self.url("/api/v2/tasks");
         let response = self
             .request(Method::POST, &url)
             .body(
@@ -66,7 +68,7 @@ impl Client {
 
     /// Delete a task specified by task_id.
     pub async fn delete_task(&self, task_id: &str) -> Result<(), RequestError> {
-        let url = format!("{}/api/v2/tasks/{}", self.url, task_id);
+        let url = self.url(&format!("/api/v2/tasks/{}", task_id));
         let response = self
             .request(Method::DELETE, &url)
             .send()

--- a/src/api/write.rs
+++ b/src/api/write.rs
@@ -17,7 +17,7 @@ impl Client {
         body: impl Into<Body> + Send,
     ) -> Result<(), RequestError> {
         let body = body.into();
-        let write_url = format!("{}/api/v2/write", self.url);
+        let write_url = self.url("/api/v2/write");
 
         let response = self
             .request(Method::POST, &write_url)


### PR DESCRIPTION
### description
- more robust handling of base url provided by the use: fixes #6 
- centralize URL generation into `Client::url(...)` method (replace all format in API folder)

seems a bit overkill as a simple check that provided url doesn't end by a slash would have done the trick, but having a method for this is easier to test as it moves the url join logic at one place

### tests
- adds a test to reproduce #6 
+ cargo test -> success