### PR TITLE
Fix typo in reqwest rustls feature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [features]
 default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
-rustls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls-tls"]
 
 [dependencies] # In alphabetical order
 influxdb2-structmap = { version = "0.2.0", path = "./influxdb2-structmap" }


### PR DESCRIPTION
It looks like instead of `rustls-tls` this attempts to turn on the feature `rustls` which doesn't appear to exist on reqwest. https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L40