### PR TITLE
Remove use of tracing `max_level` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_qs = "0.10"
 smallvec = "1.2.0"
 snafu = "0.6.6"
 tempfile = "3.1.0"
-tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
+tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "chrono", "parking_lot", "registry", "fmt", "ansi", "json"] }
 url = "2.1.1"
 


### PR DESCRIPTION
Library crates should not enable these features as they are then forced on for all downstream consumers.

If you want them enabled for test/example binaries, you can add the old dependency specification back to `dev-dependencies` where it will not indirectly affect consumers of the crate.

closes #34