### PR TITLE
Wrap the auth_header in the Client in Secret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_qs",
@@ -1219,6 +1220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,3 +1816,9 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry = { version = "0.13", default-features = false, features = ["trace
 ordered-float = "3.0"
 parking_lot = "0.11.1"
 reqwest = { version = "0.11", features = ["stream", "json"], default-features = false}
+secrecy = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 serde_qs = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@
 //! ```
 
 use reqwest::{Method, Url};
+use secrecy::{ExposeSecret, Secret};
 use snafu::Snafu;
 
 /// Errors that occur while making requests to the Influx server.
@@ -147,7 +148,7 @@ pub struct Client {
     pub base: Url,
     /// The organization tied to this client
     pub org: String,
-    auth_header: Option<String>,
+    auth_header: Option<Secret<String>>,
     reqwest: reqwest::Client,
 }
 
@@ -170,7 +171,7 @@ impl Client {
         let auth_header = if token.is_empty() {
             None
         } else {
-            Some(format!("Token {}", token))
+            Some(format!("Token {}", token).into())
         };
 
         let url: String = url.into();
@@ -189,7 +190,7 @@ impl Client {
         let mut req = self.reqwest.request(method, url);
 
         if let Some(auth) = &self.auth_header {
-            req = req.header("Authorization", auth);
+            req = req.header("Authorization", auth.expose_secret());
         }
 
         req


### PR DESCRIPTION
Resolves #36

For reference, when printed via `Debug` implementation, a `Secret<String>` appears as `Secret([REDACTED alloc::string::String])`