### PR TITLE
Make FluxRecord members public so query_raw is useful

### DIFF
--- a/influxdb2-structmap/src/value.rs
+++ b/influxdb2-structmap/src/value.rs
@@ -95,4 +95,12 @@ impl Value {
             None
         }
     }
+
+    pub fn timestamp(&self) -> Option<DateTime<FixedOffset>> {
+        if let Value::TimeRFC(timestamp) = self {
+            Some(*timestamp)
+        } else {
+            None
+        }
+    }
 }

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -382,8 +382,10 @@ struct FluxColumn {
 /// Represents a flux record returned from a query.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FluxRecord {
-    table: i32,
-    values: GenericMap,
+    /// Table id
+    pub table: i32,
+    /// Map of key/value pairs
+    pub values: GenericMap,
 }
 
 struct FluxTableMetadata {


### PR DESCRIPTION
The type `FluxRecord` returned by `query_raw` contains private members and no impl for accessing the values

```
/// Represents a flux record returned from a query.
#[derive(Clone, Debug, PartialEq)]
pub struct FluxRecord {
    table: i32,
    values: GenericMap,
}
```

This allows access to the BTreeMap (`values`) so that the records can be consumed