### PR TITLE
Simplify API query string serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,6 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_qs",
  "smallvec",
  "snafu",
  "tempfile",
@@ -1280,17 +1279,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ reqwest = { version = "0.11", features = ["stream", "json"], default-features = 
 secrecy = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
-serde_qs = "0.10"
 smallvec = "1.2.0"
 snafu = "0.6.6"
 tempfile = "3.1.0"

--- a/src/api/task.rs
+++ b/src/api/task.rs
@@ -10,16 +10,11 @@ use crate::{Client, Http, RequestError, ReqwestProcessing, Serializing};
 impl Client {
     /// List all tasks.
     pub async fn list_tasks(&self, request: ListTasksRequest) -> Result<Tasks, RequestError> {
-        let qs = serde_qs::to_string(&request).unwrap();
-        let mut endpoint = "/api/v2/tasks".to_owned();
-        if !qs.is_empty() {
-            endpoint.push('?');
-            endpoint.push_str(&qs);
-        }
-        let url = self.url(&endpoint);
+        let url = self.url("/api/v2/tasks");
 
         let response = self
             .request(Method::GET, &url)
+            .query(&request)
             .send()
             .await
             .context(ReqwestProcessing)?;


### PR DESCRIPTION
When querying with filters, the leading `?` was added to the path too early, it would end up being percent encoded (`%3f`), which in turn caused InfluxDB to return 404 errors.

This can be fixed by passing the `xxxRequest` struct directly to Reqwest's RequestBuilder which has built-in struct serialization (see [docs](https://docs.rs/reqwest/latest/reqwest/struct.RequestBuilder.html#note) or [code](https://docs.rs/reqwest/latest/src/reqwest/async_impl/request.rs.html#356)).

This also removes the `serde_qs` dependency, which was no longer used.