### PR TITLE
Added pass-through to reqwest::ClientBuilder and basic example

### DIFF
--- a/examples/with_reqwest_builder.rs
+++ b/examples/with_reqwest_builder.rs
@@ -1,0 +1,19 @@
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let influx_url = "http://localhost:8086";
+    let token = "some-token";
+
+    let builder = influxdb2::ClientBuilder::with_builder(
+        reqwest::ClientBuilder::new().user_agent(APP_USER_AGENT),
+        influx_url,
+        "org",
+        token,
+    );
+    let client = builder.build()?;
+
+    println!("{:?}", client.health().await?);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,18 @@ impl ClientBuilder {
         org: impl Into<String>,
         auth_token: impl Into<String>,
     ) -> Self {
+        Self::with_builder(reqwest::ClientBuilder::new(), url, org, auth_token)
+    }
+
+    /// Construct a new `ClientBuilder` with a provided [`reqwest::ClientBuilder`].
+    ///
+    /// Can be used to pass custom `reqwest` parameters, such as TLS configuration.
+    pub fn with_builder(
+        builder: reqwest::ClientBuilder,
+        url: impl Into<String>,
+        org: impl Into<String>,
+        auth_token: impl Into<String>,
+    ) -> Self {
         let token = auth_token.into();
         let auth_header = if token.is_empty() {
             None
@@ -244,7 +256,7 @@ impl ClientBuilder {
             base,
             org: org.into(),
             auth_header,
-            reqwest: reqwest::ClientBuilder::new(),
+            reqwest: builder,
             #[cfg(feature = "gzip")]
             compression: Compression::None,
         }


### PR DESCRIPTION
This PR adds an additional function to `influxdb2::ClientBuilder` to support a custom `reqwest::ClientBuilder` with the new `influxdb2::ClientBuilder::with_builder` function. This also modifies `influxdb2::ClientBuilder::new` to invoke the new constructor to reduce code duplication.

The motivation was primarily to support custom client-side TLS configuration through the `reqwest::tls::Identity` struct, which can be provided to a `reqwest::ClientBuilder` during its construction.

There is a basic example using a modified user-agent in `examples/with_reqwest_builder.rs`. If desired, I can put together a more comprehensive example that accepts a PEM-encoded client certificate.

Thank you.