### PR TITLE
Consolidate/update schema queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /app.env
 target/
+.vscode/**

--- a/examples/measurement.rs
+++ b/examples/measurement.rs
@@ -21,7 +21,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     for m in measurements.iter() {
-        let tag_values = client.list_measurement_tag_values(bucket, &m, "host", Some(365)).await;
+        let tag_values = client
+            .list_measurement_tag_values(bucket, &m, "host", Some(365))
+            .await;
         println!(
             "tag values for measurement {} and tag {}: {:?}",
             &m, "host", tag_values
@@ -29,7 +31,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     for m in measurements.iter() {
-        let tag_values = client.list_measurement_tag_keys(bucket, &m, Some(365)).await;
+        let tag_values = client
+            .list_measurement_tag_keys(bucket, &m, Some(365))
+            .await;
         println!(
             "tag values for measurement {} and tag {}: {:?}",
             &m, "host", tag_values

--- a/examples/measurement.rs
+++ b/examples/measurement.rs
@@ -9,19 +9,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let client = influxdb2::Client::new(influx_url, org, token);
 
-    let measurements = client.list_measurements(bucket).await.unwrap();
+    let measurements = client.list_measurements(bucket, Some(365)).await.unwrap();
     println!("measurements: {:?}", measurements);
 
     for m in measurements.iter() {
         let field_keys = client
-            .list_measurement_field_keys(bucket, &m)
+            .list_measurement_field_keys(bucket, &m, Some(365))
             .await
             .unwrap();
         println!("field keys: {:?}", field_keys);
     }
 
     for m in measurements.iter() {
-        let tag_values = client.list_measurement_tag_values(bucket, &m, "host").await;
+        let tag_values = client.list_measurement_tag_values(bucket, &m, "host", Some(365)).await;
+        println!(
+            "tag values for measurement {} and tag {}: {:?}",
+            &m, "host", tag_values
+        );
+    }
+
+    for m in measurements.iter() {
+        let tag_values = client.list_measurement_tag_keys(bucket, &m, Some(365)).await;
         println!(
             "tag values for measurement {} and tag {}: {:?}",
             &m, "host", tag_values

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -252,17 +252,21 @@ impl Client {
 
     /// Returns bucket measurements
     pub async fn list_measurements(
-        &self, 
+        &self,
         bucket: &str,
-        days_ago: Option<i64>
+        days_ago: Option<i64>,
     ) -> Result<Vec<String>, RequestError> {
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
 
-schema.measurements(bucket: "{bucket}"{}) "#, 
+schema.measurements(bucket: "{bucket}"{}) "#,
             match days_ago {
-                Some(days_ago) => { format!(", start: -{}d", days_ago) },
-                None => { String::from("") }
+                Some(days_ago) => {
+                    format!(", start: -{}d", days_ago)
+                }
+                None => {
+                    String::from("")
+                }
             }
         ));
         self.exec_schema_query(query).await
@@ -273,7 +277,7 @@ schema.measurements(bucket: "{bucket}"{}) "#,
         &self,
         bucket: &str,
         measurement: &str,
-        days_ago: Option<i64>
+        days_ago: Option<i64>,
     ) -> Result<Vec<String>, RequestError> {
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
@@ -282,9 +286,14 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 bucket: "{bucket}",
                 measurement: "{measurement}",
                 {}
-            )"#, match days_ago {
-                Some(days_ago) => { format!("start: -{}d", days_ago) },
-                None => { String::from("") }
+            )"#,
+            match days_ago {
+                Some(days_ago) => {
+                    format!("start: -{}d", days_ago)
+                }
+                None => {
+                    String::from("")
+                }
             }
         ));
         self.exec_schema_query(query).await
@@ -296,7 +305,7 @@ schema.measurements(bucket: "{bucket}"{}) "#,
         bucket: &str,
         measurement: &str,
         tag: &str,
-        days_ago: Option<i64>
+        days_ago: Option<i64>,
     ) -> Result<Vec<String>, RequestError> {
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
@@ -306,9 +315,14 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 measurement: "{measurement}",
                 tag: "{tag}",
                 {}
-            )"#, match days_ago {
-                Some(days_ago) => { format!("start: -{}d", days_ago) },
-                None => { String::from("") }
+            )"#,
+            match days_ago {
+                Some(days_ago) => {
+                    format!("start: -{}d", days_ago)
+                }
+                None => {
+                    String::from("")
+                }
             }
         ));
         self.exec_schema_query(query).await
@@ -319,7 +333,7 @@ schema.measurements(bucket: "{bucket}"{}) "#,
         &self,
         bucket: &str,
         measurement: &str,
-        days_ago: Option<i64>
+        days_ago: Option<i64>,
     ) -> Result<Vec<String>, RequestError> {
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
@@ -328,18 +342,20 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 bucket: "{bucket}",
                 measurement: "{measurement}",
                 {}
-            )"#, match days_ago {
-                Some(days_ago) => { format!("start: -{}d", days_ago) },
-                None => { String::from("") }
+            )"#,
+            match days_ago {
+                Some(days_ago) => {
+                    format!("start: -{}d", days_ago)
+                }
+                None => {
+                    String::from("")
+                }
             }
         ));
         self.exec_schema_query(query).await
     }
 
-    async fn exec_schema_query(
-        &self,
-        query: Query
-    ) -> Result<Vec<String>, RequestError> {
+    async fn exec_schema_query(&self, query: Query) -> Result<Vec<String>, RequestError> {
         let req_url = self.url("/api/v2/query");
         let body = serde_json::to_string(&query).context(Serializing)?;
 

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -256,7 +256,6 @@ impl Client {
         bucket: &str,
         days_ago: Option<i64>
     ) -> Result<Vec<String>, RequestError> {
-        let req_url = self.url("/api/v2/query");
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
 
@@ -266,8 +265,7 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 None => { String::from("") }
             }
         ));
-
-        self.exec_schema_query(&req_url, query).await
+        self.exec_schema_query(query).await
     }
 
     /// List a measurement's field keys
@@ -277,7 +275,6 @@ schema.measurements(bucket: "{bucket}"{}) "#,
         measurement: &str,
         days_ago: Option<i64>
     ) -> Result<Vec<String>, RequestError> {
-        let req_url = self.url("/api/v2/query");
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
 
@@ -290,8 +287,7 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 None => { String::from("") }
             }
         ));
-
-        self.exec_schema_query(&req_url, query).await
+        self.exec_schema_query(query).await
     }
 
     /// List keys of measurement tag
@@ -302,7 +298,6 @@ schema.measurements(bucket: "{bucket}"{}) "#,
         tag: &str,
         days_ago: Option<i64>
     ) -> Result<Vec<String>, RequestError> {
-        let req_url = self.url("/api/v2/query");
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
 
@@ -316,8 +311,7 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 None => { String::from("") }
             }
         ));
-
-        self.exec_schema_query(&req_url, query).await
+        self.exec_schema_query(query).await
     }
 
     /// List all tag values for measurement
@@ -327,8 +321,6 @@ schema.measurements(bucket: "{bucket}"{}) "#,
         measurement: &str,
         days_ago: Option<i64>
     ) -> Result<Vec<String>, RequestError> {
-
-        let req_url = self.url("/api/v2/query");
         let query = Query::new(format!(
             r#"import "influxdata/influxdb/schema"
             
@@ -341,15 +333,14 @@ schema.measurements(bucket: "{bucket}"{}) "#,
                 None => { String::from("") }
             }
         ));
-        self.exec_schema_query(&req_url, query).await
+        self.exec_schema_query(query).await
     }
 
     async fn exec_schema_query(
-        &self, 
-        req_url: &str, 
+        &self,
         query: Query
     ) -> Result<Vec<String>, RequestError> {
-
+        let req_url = self.url("/api/v2/query");
         let body = serde_json::to_string(&query).context(Serializing)?;
 
         let response = self


### PR DESCRIPTION
Per the [docs](https://docs.influxdata.com/flux/v0/stdlib/influxdata/influxdb/schema/measurementtagvalues/) there is an optional 'start' value, in negative days, that can be added to schema queries. This PR:
* adds an optional param to those functions dictating the start of the search
* implements the 'measurementTagKeys' function
* consolidates the schema query execution because they were all identical

Tested on my local influx server with Some() and None values