### PR TITLE
Fixed query creation for Option` values #56

### DIFF
--- a/influxdb2-derive/tests/writable.rs
+++ b/influxdb2-derive/tests/writable.rs
@@ -9,7 +9,9 @@ struct Item {
     name2: String,
     #[influxdb(field)]
     field1: u64,
+    #[influxdb(field)]
     field2: i64,
+    #[influxdb(field)]
     field3: String,
     #[influxdb(timestamp)]
     time: u64,
@@ -19,15 +21,83 @@ struct Item {
 #[measurement = "something"]
 struct Item2 {
     #[influxdb(tag)]
-    name: Option<String>,
+    name: String,
     #[influxdb(tag)]
-    name2: Option<String>,
+    name2: String,
     #[influxdb(field)]
     field1: Option<u64>,
-    field2: i64,
+    #[influxdb(field)]
+    field2: Option<i64>,
     #[influxdb(timestamp)]
     time: u64,
 }
+
+#[derive(WriteDataPoint)]
+#[measurement = "barfoo"]
+struct Item3 {
+    #[influxdb(tag)]
+    name: String,
+    #[influxdb(field)]
+    field1: Option<String>,
+    #[influxdb(field)]
+    field2: Option<String>,
+    #[influxdb(field)]
+    field3: Option<f64>,
+    #[influxdb(field)]
+    field4: Option<f64>,
+    #[influxdb(field)]
+    field5: Option<i64>,
+    #[influxdb(timestamp)]
+    time: u64,
+}
+
+#[derive(WriteDataPoint)]
+#[measurement = "barfoo2"]
+struct Item4 {
+    #[influxdb(tag)]
+    tag1: Option<String>,
+    #[influxdb(tag)]
+    tag2: Option<String>,
+    #[influxdb(tag)]
+    tag3: Option<String>,
+    #[influxdb(tag)]
+    tag4: Option<String>,
+    #[influxdb(tag)]
+    tag5: Option<String>,
+    #[influxdb(field)]
+    field1: String,
+    #[influxdb(timestamp)]
+    time: u64,
+}
+
+
+#[derive(WriteDataPoint)]
+#[measurement = "foobar"]
+struct Item5 {
+    #[influxdb(tag)]
+    tag1: Option<String>,
+    #[influxdb(tag)]
+    tag2: Option<String>,
+    #[influxdb(tag)]
+    tag3: Option<String>,
+    #[influxdb(tag)]
+    tag4: Option<String>,
+    #[influxdb(tag)]
+    tag5: Option<String>,
+    #[influxdb(field)]
+    field1: Option<String>,
+    #[influxdb(field)]
+    field2: Option<String>,
+    #[influxdb(field)]
+    field3: Option<f64>,
+    #[influxdb(field)]
+    field4: Option<f64>,
+    #[influxdb(field)]
+    field5: Option<i64>,
+    #[influxdb(timestamp)]
+    time: u64,
+}
+
 fn main() {
     use influxdb2::models::WriteDataPoint;
     use std::io::Write;
@@ -37,32 +107,94 @@ fn main() {
         field1: 32u64,
         field2: 33i64,
         field3: "hello".to_string(),
-        time: 222222u64,
+        time: 222233u64,
     };
 
     let mut writer = Vec::new();
     item.write_data_point_to(&mut writer).unwrap();
     writer.flush().unwrap();
-    println!("{}", std::str::from_utf8(&writer).unwrap());
+    println!("Writer: {}", std::str::from_utf8(&writer).unwrap());
     assert_eq!(
         &writer[..],
-        b"something,name=foo,name2=bar field1=32u,field2=33i,field3=\"hello\" 222222\n"
+        b"something,name=foo,name2=bar field1=32u,field2=33i,field3=\"hello\" 222233\n"
     );
 
     let item = Item2 {
-        name: Some("foo".to_string()),
-        name2: None,
+        name: "foo".to_string(),
+        name2: "bar".to_string(),
         field1: None,
-        field2: 33i64,
+        field2: Some(33i64),
         time: 222222u64,
     };
 
     let mut writer = Vec::new();
     item.write_data_point_to(&mut writer).unwrap();
     writer.flush().unwrap();
-    println!("{}", std::str::from_utf8(&writer).unwrap());
+    println!("Writer: {}", std::str::from_utf8(&writer).unwrap());
     assert_eq!(
         &writer[..],
-        b"something,name=foo,name2=None field1=\"None\",field2=33i 222222\n"
-    )
+        b"something,name=foo,name2=bar field2=33i 222222\n"
+    );
+
+    let item = Item3 {
+        name: "foo".to_string(),
+        field1: None,
+        field2: None,
+        field3: Some(12.34),
+        field4: None,
+        field5: None,
+        time: 222222u64,
+    };
+
+    let mut writer = Vec::new();
+    item.write_data_point_to(&mut writer).unwrap();
+    writer.flush().unwrap();
+    println!("Writer: {}", std::str::from_utf8(&writer).unwrap());
+    assert_eq!(
+        &writer[..],
+        b"barfoo,name=foo field3=12.34 222222\n"
+    );
+
+    let item = Item4 {
+        tag1: None,
+        tag2: None,
+        tag3: Some("thisIsATag".to_string()),
+        tag4: None,
+        tag5: None,
+        field1: "asdf".to_string(),
+        time: 222222u64,
+    };
+
+    let mut writer = Vec::new();
+    item.write_data_point_to(&mut writer).unwrap();
+    writer.flush().unwrap();
+    println!("Writer: {}", std::str::from_utf8(&writer).unwrap());
+    assert_eq!(
+        &writer[..],
+        b"barfoo2,tag3=thisIsATag field1=\"asdf\" 222222\n"
+    );
+
+    let item = Item5 {
+        tag1: None,
+        tag2: None,
+        tag3: Some("thisIsATag".to_string()),
+        tag4: None,
+        tag5: None,
+        field1: None,
+        field2: None,
+        field3: Some(12.34),
+        field4: None,
+        field5: None,
+        time: 222222u64,
+    };
+
+    let mut writer = Vec::new();
+    item.write_data_point_to(&mut writer).unwrap();
+    writer.flush().unwrap();
+    println!("Writer: {}", std::str::from_utf8(&writer).unwrap());
+    assert_eq!(
+        &writer[..],
+        b"foobar,tag3=thisIsATag field3=12.34 222222\n"
+    );
+
 }

--- a/src/writable.rs
+++ b/src/writable.rs
@@ -198,6 +198,18 @@ mod tests {
     }
 
     #[test]
+    fn value_writable_option_f64_not_none() {
+        let a: Option<f64> = Some(78.4);
+        assert_eq!(a.encode_value(), "78.4");
+    }
+
+    #[test]
+    fn value_writable_option_f64_none() {
+        let a: Option<f64> = None;
+        assert_eq!(a.encode_value(), "None");
+    }
+
+    #[test]
     fn tags_tuple() {
         let a: (&str, &str) = ("33", "str");
         assert_eq!(a.encode_tags(), "33=str");

--- a/src/writable.rs
+++ b/src/writable.rs
@@ -77,7 +77,7 @@ impl<T: ValueWritable> ValueWritable for Option<T> {
     fn encode_value(&self) -> String {
         match self {
             Some(v) => v.encode_value(),
-            None => "\"None\"".to_string(),
+            None => "None".to_string(),
         }
     }
 }


### PR DESCRIPTION
If an option type is used, and it is None, then the tag / field will be excluded from the query, because this is the only working way to transmit null values to the database.

This behavior introduces a bug that may lead to an invalid query. The problem arises when a struct contains only option values for the tags and or fields, because then if every option value is `None` every tag / field will be excluded. This breaks the rule that at least one tag / field must exist. 

https://github.com/aprimadi/influxdb2/blob/11b8b9d23568d09672cf8ed85b7d878c0deaa8e4/influxdb2-derive/src/expand_writable.rs#L99-L107

In my opinion, this bug is more acceptable than the currently non-functional implementation for options.

I just started out with Rust, so feedback is highly appreciated :) 