### PR TITLE
fixed README.md to include all used deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Add this to `cargo.toml`:
 ```toml
 influxdb2 = "0.3"
 influxdb2-structmap = "0.2"
+influxdb2-derive = "0.1.1"
 num-traits = "0.2"
 ```
 


### PR DESCRIPTION
The README mentions what libraries to use but does not include all. The derive macros are beeing used and the relevant library is not beeing mentioned.

Stupid small change but just a quality of life thing