### PR TITLE
Added integration Test Step to CI, clippy code cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    id: build
     needs: typos
     steps:
     - name: Clone this repository
@@ -55,7 +54,6 @@ jobs:
   test: 
     name: Run Tests
     runs-on: ubuntu-latest
-    id: test
     needs: build
     steps:
     - name: Clone this repository

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    id: build
+    needs: typos
     steps:
     - name: Clone this repository
       uses: actions/checkout@v4
@@ -50,5 +52,20 @@ jobs:
     - name: Build
       run: cargo build --verbose
 
+  test: 
+    name: Run Tests
+    runs-on: ubuntu-latest
+    id: test
+    needs: build
+    steps:
+    - name: Clone this repository
+      uses: actions/checkout@v4
+    
+    - name: Rust Toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - name: Update Stable Rust toolchain
+      run: rustup update stable
+
     - name: Run tests
-      run: cargo test --verbose
+      run: TEST_INTEGRATION=true cargo test --verbose

--- a/examples/measurement.rs
+++ b/examples/measurement.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for m in measurements.iter() {
         let field_keys = client
-            .list_measurement_field_keys(bucket, &m, Some("-365d"), Some("now()"))
+            .list_measurement_field_keys(bucket, m, Some("-365d"), Some("now()"))
             .await
             .unwrap();
         println!("field keys: {:?}", field_keys);
@@ -25,21 +25,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for m in measurements.iter() {
         let tag_values = client
-            .list_measurement_tag_values(bucket, &m, "host", Some("-365d"), None)
+            .list_measurement_tag_values(bucket, m, "host", Some("-365d"), None)
             .await;
         println!(
-            "tag values for measurement {} and tag {}: {:?}",
-            &m, "host", tag_values
+            "tag values for measurement {} and tag host: {:?}",
+            &m, tag_values
         );
     }
 
     for m in measurements.iter() {
         let tag_values = client
-            .list_measurement_tag_keys(bucket, &m, Some("-365d"), None)
+            .list_measurement_tag_keys(bucket, m, Some("-365d"), None)
             .await;
         println!(
-            "tag values for measurement {} and tag {}: {:?}",
-            &m, "host", tag_values
+            "tag values for measurement {} and tag host: {:?}",
+            &m, tag_values
         );
     }
 

--- a/src/api/authorizations.rs
+++ b/src/api/authorizations.rs
@@ -30,7 +30,7 @@ impl Client {
             return res;
         }
 
-        Ok(response.json().await.context(ReqwestProcessing)?)
+        response.json().await.context(ReqwestProcessing)
     }
 
     /// Create a new authorization in the organization.

--- a/src/api/label.rs
+++ b/src/api/label.rs
@@ -9,12 +9,12 @@ use std::collections::HashMap;
 impl Client {
     /// List all Labels
     pub async fn labels(&self) -> Result<LabelsResponse, RequestError> {
-        Ok(self.get_labels(None).await?)
+        self.get_labels(None).await
     }
 
     /// List all Labels by organization ID
     pub async fn labels_by_org(&self, org_id: &str) -> Result<LabelsResponse, RequestError> {
-        Ok(self.get_labels(Some(org_id)).await?)
+        self.get_labels(Some(org_id)).await
     }
 
     async fn get_labels(&self, org_id: Option<&str>) -> Result<LabelsResponse, RequestError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,8 @@ impl ClientBuilder {
         };
 
         let url: String = url.into();
-        let base = Url::parse(&url).expect(&format!("Invalid url was provided: {}", &url));
+        let base =
+            Url::parse(&url).unwrap_or_else(|_| panic!("Invalid url was provided: {}", &url));
 
         Self {
             base,

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::await_holding_lock)]
+
 use once_cell::sync::OnceCell;
 use std::{
     fs::File,
@@ -223,7 +225,7 @@ impl TestServer {
                 .arg("--pull")
                 .arg("always")
                 .arg("--detach")
-                .arg(&ci_image)
+                .arg(ci_image)
                 .arg("influxd")
                 .output()
                 .expect("starting of docker server process");


### PR DESCRIPTION
- Remove unnecessary references
- Added integration test running to GitlabCI
- general code cleanup 

Clippy was complaining about holding a `parking_lot` mutex across an await point. 
Internally, 
I am not 100% sure if we want to switch that to a `tokio::mutex` 
I imagine it should not impact the test, but i left a lint disabling clippy from complaining, for the time being. 