### PR TITLE
fix(ast): Force serialization of required field

### DIFF
--- a/src/models/file.rs
+++ b/src/models/file.rs
@@ -15,7 +15,7 @@ pub struct File {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub package: Option<crate::models::ast::PackageClause>,
     /// A list of package imports
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub imports: Vec<crate::models::ast::ImportDeclaration>,
     /// List of Flux statements
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
It seems that `File::imports` is required to either be null or set, but not unset.

(see https://github.com/influxdata/flux/blob/master/libflux/flux-core/src/ast/mod.rs#L571-L572)