### PR TITLE
fix: encode_value add escaping

### DIFF
--- a/src/writable.rs
+++ b/src/writable.rs
@@ -51,13 +51,13 @@ impl ValueWritable for u64 {
 
 impl ValueWritable for String {
     fn encode_value(&self) -> String {
-        format!("\"{}\"", self)
+        format!("\"{}\"", self.replace("\\", "\\\\").replace("\"", "\\\""))
     }
 }
 
 impl ValueWritable for &str {
     fn encode_value(&self) -> String {
-        format!("\"{}\"", self)
+        format!("\"{}\"", self.replace("\\", "\\\\").replace("\"", "\\\""))
     }
 }
 


### PR DESCRIPTION
When the value of a field contains double quotes (") or backslashes (\), failing to escape them will result in malformed Line Protocol strings that cannot be parsed correctly.